### PR TITLE
use UpdatePositionToAnchor in OnUpdate

### DIFF
--- a/ActionMenu/ActionMenu.cs
+++ b/ActionMenu/ActionMenu.cs
@@ -1273,7 +1273,7 @@ namespace ActionMenu
         {
             if (Input.GetKeyDown(KeyCode.F3)) Reload(); // reload
 
-            if (menuTransform != null) UpdatePositionToVrAnchor();
+            if (menuTransform != null) UpdatePositionToAnchor();
         }
 
         internal class OurLib : Lib


### PR DESCRIPTION
OnUpdate used VR anchor when menu was closed, causing the menu to snap to the hand on desktop during the closing animation.

https://user-images.githubusercontent.com/37721153/191069148-870f3f93-618a-4dbb-a42a-87ac572f063c.mp4