### PR TITLE
ActionMenu: overcrowdedMenuValue = 8 (like vrc)

### DIFF
--- a/ActionMenu/ActionMenu.cs
+++ b/ActionMenu/ActionMenu.cs
@@ -523,7 +523,7 @@ namespace ActionMenu
             return ReifyHierarchyInNames(m);
         }
 
-        public static Menus SplitOverCrowdedMenus(Menus m, uint overcrowdedMenuValue = 7)
+        public static Menus SplitOverCrowdedMenus(Menus m, uint overcrowdedMenuValue = 8)
         {
             var pagePrefix = "page-";
             var keys = m.Keys.OrderBy(n => -n.Length).ToArray(); // process bottom-up (deepest first)


### PR DESCRIPTION
I have revived the VRC to CVR conversion tool ([VRC3CVR](https://github.com/Narazaka/vrc3cvr)), but the number limit for the crowded menu is 7 and the VRC menu limit is 8, so with the current number limit, one item ends up being separated.
That’s why I think a limit of 8 would be more useful.