### PR TITLE
ActionMenu: <hidden> parameters

### DIFF
--- a/ActionMenu/ActionMenu.cs
+++ b/ActionMenu/ActionMenu.cs
@@ -568,6 +568,8 @@ namespace ActionMenu
         {
             var item = new MenuItem();
 
+            if (s.name.EndsWith("<hidden>")) return null;
+
             // build the items in the menu
             switch (s.type)
             {

--- a/ActionMenu/README.md
+++ b/ActionMenu/README.md
@@ -19,6 +19,7 @@ The avatar submenu is automatically generated from the avatar CVR "Advanced Sett
 
 - You can use slashes `/` in the parameter "Name" text field to make submenu. For example let's say you have two parameters `Clothing/Dress/Long` and `Clothing/Dress/Short`. That means the submenus will be: Avatar > Clothing > Dress which will contain two items: Long and Short.
 - You can append "Impulse" in the "Parameter" text field to make it a temporary trigger type. Meaning it will set its value for half a second only. Useful to trigger things.
+- You can append "&lt;hidden>&gt;" to the "Name" text field to hide it from the menu.
 
 If you aren't the owner of the avatar you can still customize through JSON overrides, see below.
  


### PR DESCRIPTION
There are parameters that are controlled from Animator Driver, CVR Advanced Avatar Trigger, etc. and are not used from the menu.
An option to not display these parameters in the Action Menu would be useful.
(I also [plan](https://github.com/Narazaka/vrc3cvr/pull/7) to add a feature that automatically adds <hidden> to the conversion menu in VRC3CVR when this is merged.)

- Why is Impulse the parameter name and this one the menu name?
  - Because changing the parameter name has a large impact, and I think it is better to be able to specify Impulse by menu name in the first place.
