### PR TITLE
ActionMenu: Impulse by menu name <impulse>

### DIFF
--- a/ActionMenu/ActionMenu.cs
+++ b/ActionMenu/ActionMenu.cs
@@ -599,7 +599,7 @@ namespace ActionMenu
                     };
 
                     List<MenuItem> sitems = dd.options.Select((o, index) => {
-                        var (control, duration) = DetectImpulseToggle(s);
+                        var (control, duration) = DetectImpulseToggle(o);
                         if (control == "toggle")
                         {
                             control = parentControl;


### PR DESCRIPTION
Changing the parameter name has a large impact, and I think it is better to be able to specify Impulse by menu name.

- `<impulse>`: 1s duration (current)
- `<impulse=0.5>`: 0.5s duration